### PR TITLE
Enable listening with IPv6 or IPv4 (previously only IPv4 was possible)

### DIFF
--- a/src/mummy.nim
+++ b/src/mummy.nim
@@ -1366,8 +1366,8 @@ proc serve*(
   address = "localhost"
 ) {.raises: [MummyError].} =
   ## The server will serve on the address and port. The default address is
-  ## localhost. Use "0.0.0.0" to make the server externally accessible (with
-  ## caution).
+  ## localhost. Use "0.0.0.0" or "::" to make the server externally
+  ## accessible (with caution).
   ## This call does not return unless server.close() is called from another
   ## thread.
 
@@ -1375,10 +1375,18 @@ proc serve*(
     raise newException(MummyError, "Server already has a socket")
 
   try:
-    server.socket = createNativeSocket(
-      Domain.AF_INET,
+    let ai = getAddrInfo(
+      address,
+      port,
+      Domain.AF_UNSPEC,
       SockType.SOCK_STREAM,
       Protocol.IPPROTO_TCP,
+    )
+
+    server.socket = createNativeSocket(
+      ai.ai_family,
+      ai.ai_socktype,
+      ai.ai_protocol,
       false
     )
     if server.socket == osInvalidSocket:
@@ -1387,13 +1395,6 @@ proc serve*(
     server.socket.setBlocking(false)
     server.socket.setSockOptInt(SOL_SOCKET, SO_REUSEADDR, 1)
 
-    let ai = getAddrInfo(
-      address,
-      port,
-      Domain.AF_INET,
-      SockType.SOCK_STREAM,
-      Protocol.IPPROTO_TCP,
-    )
     try:
       if bindAddr(server.socket, ai.ai_addr, ai.ai_addrlen.SockLen) < 0:
         raiseOSError(osLastError())

--- a/tests/test_websockets.nim
+++ b/tests/test_websockets.nim
@@ -53,7 +53,7 @@ var requesterThread: Thread[void]
 proc requesterProc() =
   server.waitUntilReady()
 
-  let websocket = waitFor newWebSocket("ws://127.0.0.1:8081")
+  let websocket = waitFor newWebSocket("ws://localhost:8081")
   doAssert (waitFor websocket.receiveStrPacket()) == "First"
   doAssert (waitFor websocket.receiveStrPacket()) == "Second"
   waitFor websocket.send("Third")


### PR DESCRIPTION
I found that I couldn't specify an IPv6 address to listen on, so I made this tiny modification to enable it.

Any of the following are possible with it;

```
...

server.serve(Port(80), "localhost")
server.serve(Port(80), "127.0.0.1")
server.serve(Port(80), "::1")
server.serve(Port(80), "0.0.0.0")
server.serve(Port(80), "::")
```

The change is simply to call `getAddrInfo` with `Domain.AF_UNSPEC` then to use the result from `getAddrInfo` as arguments to `createNativeSocket` so we get a socket that matches the capabilities as probed by `getAddrInfo`.