### PR TITLE
Enable listening with IPv6 or IPv4 (non-Windows only)

### DIFF
--- a/tests/test_websockets.nim
+++ b/tests/test_websockets.nim
@@ -53,7 +53,7 @@ var requesterThread: Thread[void]
 proc requesterProc() =
   server.waitUntilReady()
 
-  let ws = newWebSocket("ws://127.0.0.1:8081")
+  let ws = newWebSocket("ws://localhost:8081")
   doAssert ws.receiveMessage() ==
     some(whisky.Message(kind: whisky.TextMessage, data: "First"))
   doAssert ws.receiveMessage() ==


### PR DESCRIPTION
This PR allows listening on an IPv6 address except on Windows, which it forces to fallback to IPv4.

This is to cover the case when the user specifies "localhost", which will likely detect and try to use IPv6, but for reasons yet to be determined, does not work on Windows (causing the server to be unresponsive).

It is #39 with a workaround due to lack of time/familiarity-with-Windows to fix the actual issue on Windows.