### PR TITLE
Make routes public

### DIFF
--- a/src/mummy/routers.nim
+++ b/src/mummy/routers.nim
@@ -9,7 +9,7 @@ type
       ## Called when the HTTP method is not registered for the route
     errorHandler*: RequestErrorHandler
       ## Called when the route request handler raises an Exception
-    routes: seq[Route]
+    routes*: seq[Route]
 
   RequestErrorHandler* = proc(request: Request, e: ref Exception) {.gcsafe.}
 


### PR DESCRIPTION
By making the `routes: seq[Route]` public it's possible to create `Router` elements in different files and combine them later.

fileA.nim
```nim
import
  mummy, mummy/routers

var contractsRouter*: Router
contractsRouter.get("/contracts/api/items", routeContractsApiItems)
contractsRouter.get("/contracts/api/approvals", routeContractsApiApprovals)
```

fileB.nim
```nim
import
  mummy, mummy/routers

var personRouter*: Router
personRouter.get("/person/api/names", routePersonApiNames)
personRouter.get("/person/api/emails", routePersonApiEmails)
```

fileC.nim
```nim
import
  mummy, mummy/routers

import
  ./fileA,
  ./fileB

var mainRouter: Router
mainRouter.get("/", routeMain)
mainRouter.get("/login", routeMainLogin)

for route in contractsRouter.routes:
  mainRouter.route.add(route)

for route in personRouter.routes:
  mainRouter.route.add(route)

let server = newServer(mainRouter)

server.serve(Port(8080))
```
