### PR TITLE
stricter parsing

### DIFF
--- a/src/mummy.nim
+++ b/src/mummy.nim
@@ -911,7 +911,7 @@ proc afterRecvHttp(
           # Found both Transfer-Encoding: chunked and Content-Length headers
           return true # Close the connection
         try:
-          dataEntry.requestState.contentLength = parseInt(v)
+          dataEntry.requestState.contentLength = strictParseInt(v)
         except:
           return true # Parsing Content-Length failed, close the connection
       elif cmpIgnoreCase(k, "Transfer-Encoding") == 0:
@@ -971,12 +971,8 @@ proc afterRecvHttp(
       # After we know we've seen the end of the chunk length, parse it
       var chunkLen: int
       try:
-        discard parseHex(
-          dataEntry.recvBuf,
-          chunkLen,
-          0,
-          chunkLenEnd
-        )
+        chunkLen =
+          strictParseHex(dataEntry.recvBuf.toOpenArray(0, chunkLenEnd - 1))
       except:
         return true # Parsing chunk length failed, close the connection
 

--- a/tests/fuzz_recv.nim
+++ b/tests/fuzz_recv.nim
@@ -150,7 +150,7 @@ block:
         encoded: string
       while true:
         let chunkLen = min(rand(1 ..< 4096), body.len - pos)
-        encoded &= toHex(chunkLen)
+        encoded &= toHexWithoutLeadingZeroes(chunkLen)
         encoded &= "\r\n"
         encoded &= body[pos ..< pos + chunkLen]
         encoded &= "\r\n"
@@ -172,12 +172,12 @@ block:
           clientSocket,
           dataEntry
         )
-      if not closingConnection:
-        let request = server.taskQueue.popFirst().request
-        doAssert request.headers.headerContainsToken(
-          "Transfer-Encoding", "chunked"
-        )
-        doAssert request.body == body
+      doAssert not closingConnection
+      let request = server.taskQueue.popFirst().request
+      doAssert request.headers.headerContainsToken(
+        "Transfer-Encoding", "chunked"
+      )
+      doAssert request.body == body
       server.close()
 
   block:
@@ -215,6 +215,7 @@ block:
             "Content-Length", $body.len
           )
           doAssert request.body == body
+          dec dataEntry.requestCounter
         server.close
 
       block:

--- a/tests/test.nim
+++ b/tests/test.nim
@@ -1,4 +1,4 @@
-import mummy {.all.}
+import mummy {.all.}, mummy/internal, std/strutils
 
 block:
   var headers: HttpHeaders
@@ -24,3 +24,61 @@ block:
   doAssert headers.headerContainsToken("2", "dd")
   doAssert headers.headerContainsToken("2", "DD")
   doAssert not headers.headerContainsToken("2", "d")
+
+block:
+  for i in 0 ..< 10_000:
+    doAssert strictParseInt($i) == i
+
+  doAssert strictParseInt("-1") == -1
+
+  doAssert strictParseInt("9223372036854775807") == 9223372036854775807
+  doAssert strictParseInt("-9223372036854775808") == -9223372036854775808
+
+  doAssertRaises ValueError:
+    discard strictParseInt("")
+
+  doAssertRaises ValueError:
+    discard strictParseInt("+")
+
+  doAssertRaises ValueError:
+    discard strictParseInt("-")
+
+  doAssertRaises ValueError:
+    discard strictParseInt("-0")
+
+  doAssertRaises ValueError:
+    discard strictParseInt("+1")
+
+  doAssertRaises ValueError:
+    discard strictParseInt("010")
+
+  doAssertRaises ValueError:
+    discard strictParseInt("9223372036854775808")
+
+  doAssertRaises ValueError:
+    discard strictParseInt("-9223372036854775809")
+
+block:
+  doAssertRaises ValueError:
+    discard strictParseHex("")
+
+  doAssertRaises ValueError:
+    discard strictParseHex("00")
+
+  doAssertRaises ValueError:
+    discard strictParseHex("0f")
+
+  doAssertRaises ValueError:
+    discard strictParseHex("0x1")
+
+  for i in 0 ..< 10_000:
+    doAssert strictParseHex(toHexWithoutLeadingZeroes(i)) == i
+
+  doAssert strictParseHex("7FFFFFFFFFFFFFFF") == 9223372036854775807
+
+  doAssertRaises ValueError:
+    discard strictParseHex("8FFFFFFFFFFFFFFF")
+
+  discard strictParseHex("1111111111111111")
+  doAssertRaises ValueError:
+    discard strictParseHex("11111111111111111")


### PR DESCRIPTION
nim's int and hex parsing is permissive (allows _ or leading 0x or leading zeroes, +, etc) but this is not valid for HTTP and can cause issues. better to be strict.