### PR TITLE
allow logger with existing file object

### DIFF
--- a/src/mummy/fileloggers.nim
+++ b/src/mummy/fileloggers.nim
@@ -121,10 +121,10 @@ proc writerProc(logger: FileLogger) {.raises: [].} =
       return
 
 proc newFileLogger*(
-  filePath: string
+  file: File
 ): FileLogger {.raises: [IOError, ResourceExhaustedError].} =
   result = cast[FileLogger](allocShared0(sizeof(FileLoggerObj)))
-  result.file = open(filePath, fmAppend)
+  result.file = file
   initLock(result.queueLock)
   initLock(result.writeLock)
   initCond(result.cond)
@@ -133,3 +133,9 @@ proc newFileLogger*(
   except ResourceExhaustedError as e:
     result.destroy()
     raise e
+
+proc newFileLogger*(
+  filePath: string
+): FileLogger {.raises: [IOError, ResourceExhaustedError].} =
+  newFileLogger(open(filePath, fmAppend))
+


### PR DESCRIPTION
Hi, thanks for making mummy!!!

For your consideration, I made a small modification to the logger initialization code to support existing file objects- mostly to use the existing Nim-initialized `stdout` or `stderr` in a thread safe way for logging to systemd, but also just flexibility.

One could theoretically keep the old `newFileLogger` proc and add the new one alongside instead of calling it. That way there would be no change of existing code paths, but some new duplication. Let me know if you would prefer this, or other changes.

Thanks for having a look!