### PR TITLE
Fix router test failures with two critical bug fixes

### DIFF
--- a/src/mummy/routers.nim
+++ b/src/mummy/routers.nim
@@ -158,7 +158,7 @@ proc defaultMethodNotAllowedHandler(request: Request) =
     request.respond(405, headers, body)
 
 proc isPartialWildcard(test: string): bool {.inline.} =
-  test.len >= 2 and test.startsWith('*') or test.endsWith('*')
+  test.len >= 2 and (test.startsWith('*') or test.endsWith('*'))
 
 proc partialWildcardMatches(partialWildcard, test: string): bool {.inline.} =
   let
@@ -278,8 +278,7 @@ proc toHandler*(router: Router): RequestHandler =
           defaultMethodNotAllowedHandler(request)
       else:
         notFound()
-    except:
-      let e = getCurrentException()
+    except Exception as e:
       if router.errorHandler != nil:
         router.errorHandler(request, e)
       else:


### PR DESCRIPTION
1. **Operator precedence bug in isPartialWildcard**: Fixed incorrect boolean operator precedence that was causing any string ending with '*' to be considered a partial wildcard regardless of length requirement. Changed: test.len >= 2 and test.startsWith('*') or test.endsWith('*') To: test.len >= 2 and (test.startsWith('*') or test.endsWith('*'))

2. **Exception handling bug**: Fixed router exception handling that wasn't properly catching AssertionDefect. The generic except: block doesn't catch AssertionDefect in Nim, causing test failures when notFoundHandler called doAssert false. Changed: except: to except Exception as e:

🤖 Generated with [Claude Code](https://claude.ai/code)