### PR TITLE
Adds SSE (Server-Sent Events) Support

### DIFF
--- a/examples/simple_sse.nim
+++ b/examples/simple_sse.nim
@@ -1,0 +1,83 @@
+## Simple Server-Sent Events (SSE) example for Mummy (copied from mummyx, by Göran Krampe)
+## Run with: nim c --threads:on --mm:orc -r examples/simple_sse.nim
+
+import std/times, ../src/mummy, std/os
+
+var sseConnection: SSEConnection
+
+proc handleRequest(request: Request) =
+  if request.path == "/events":
+    echo "[SSE] New connection from: ", request.remoteAddress
+
+    sseConnection = request.respondSSE()
+
+    # Send initial event
+    sseConnection.send(SSEEvent(
+      data: """{"message": "Connected to SSE stream", "time": """ & $now() & """""""
+    ))
+
+    # Send a few events with delay
+    for i in 1 .. 5:
+      sleep(1000)
+      sseConnection.send(SSEEvent(
+        data: """{"count": """ & $i & """, "time": """ & $now() & """""""
+      ))
+
+    # Send final event and close
+    sleep(1000)
+    sseConnection.send(SSEEvent(
+      data: """{"message": "Stream complete"}"""
+    ))
+    close(sseConnection)
+
+  elif request.path == "/":
+    request.respond(200, @[
+      ("Content-Type", "text/html")
+    ], """
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Mummy SSE Example</title>
+  <style>
+    body { font-family: Arial; max-width: 800px; margin: 50px auto; }
+    #events { background: #f5f5f5; padding: 20px; border-radius: 5px; }
+    .event { margin: 10px 0; padding: 10px; background: white; }
+  </style>
+</head>
+<body>
+  <h1>Mummy SSE Example</h1>
+  <button onclick="startSSE()">Start SSE Stream</button>
+  <div id="events"></div>
+
+  <script>
+    function startSSE() {
+      const events = document.getElementById('events');
+      events.innerHTML = '<p>Connecting...</p>';
+
+      const evtSource = new EventSource('/events');
+
+      evtSource.onmessage = function(e) {
+        const eventDiv = document.createElement('div');
+        eventDiv.className = 'event';
+        eventDiv.textContent = e.data;
+        events.appendChild(eventDiv);
+      };
+
+      evtSource.onerror = function() {
+        events.innerHTML += '<p>Connection closed</p>';
+        evtSource.close();
+      };
+    }
+  </script>
+</body>
+</html>
+""")
+
+  else:
+    request.respond(404)
+
+when isMainModule:
+  let server = newServer(handleRequest)
+  echo "SSE Example Server running on http://localhost:8080"
+  echo "Open http://localhost:8080 in your browser"
+  server.serve(Port(8080))

--- a/examples/sse_stream_close.nim
+++ b/examples/sse_stream_close.nim
@@ -1,0 +1,29 @@
+# Minimal headless SSE demo: POST /stream streams 2 integers in JSON then closes (copied from mummyx, by Jory Schossau)
+import ../src/mummy, ../src/mummy/routers
+import std/[times, options, os]
+
+proc handleStream(req: Request) {.gcsafe.} =
+  if req.httpMethod != "POST":
+    req.respond(405, @[ ("Content-Type", "text/plain") ], "Method Not Allowed\n")
+    return
+
+  var connection = req.respondSSE()
+  for i in 1..2:
+    let payload = "{\"n\": " & $i & "}"
+    connection.send(SSEEvent(
+      event: none(string),
+      data: $payload,
+      id: none(string)
+    ))
+    sleep(600)
+  connection.close()
+
+proc main() =
+  var router = Router()
+  router.post("/stream", handleStream)
+  let server = newServer(router)
+  echo "POST /stream for SSE events at http://localhost:8080"
+  server.serve(Port(8080))
+
+when isMainModule:
+  main()

--- a/tests/test_sse.nim
+++ b/tests/test_sse.nim
@@ -1,0 +1,114 @@
+## Tests for Server-Sent Events (SSE) implementation
+
+import ../src/mummy {.all.}, ../src/mummy/internal, std/options, std/nativesockets
+
+block:
+  # Simple data event
+  let event = SSEEvent(data: "Hello")
+  doAssert formatSSEEvent(event) == "data: Hello\n\n"
+
+block:
+  # Event with type
+  let event = SSEEvent(event: some("message"), data: "Hi")
+  doAssert formatSSEEvent(event) == "event: message\ndata: Hi\n\n"
+
+block:
+  # Event with id
+  let event = SSEEvent(id: some("123"), data: "Test")
+  doAssert formatSSEEvent(event) == "id: 123\ndata: Test\n\n"
+
+block:
+  # Event with retry
+  let event = SSEEvent(retry: some(5000), data: "Test")
+  doAssert formatSSEEvent(event) == "retry: 5000\ndata: Test\n\n"
+
+block:
+  # Multiline data
+  let event = SSEEvent(data: "Line 1\nLine 2")
+  doAssert formatSSEEvent(event) == "data: Line 1\ndata: Line 2\n\n"
+
+block:
+  # Multiline data with trailing newline
+  let event = SSEEvent(data: "Line 1\nLine 2\n")
+  doAssert formatSSEEvent(event) == "data: Line 1\ndata: Line 2\n\n"
+
+block:
+  # All fields present
+  let event = SSEEvent(
+    event: some("update"),
+    data: "test",
+    id: some("123"),
+    retry: some(5000)
+  )
+  let expected = "event: update\nid: 123\nretry: 5000\ndata: test\n\n"
+  doAssert formatSSEEvent(event) == expected
+
+block:
+  # Empty data
+  let event = SSEEvent(data: "")
+  doAssert formatSSEEvent(event) == "\n"
+
+block:
+  # SSEEvent default values
+  let event = SSEEvent()
+  doAssert event.event.isNone == true
+  doAssert event.id.isNone == true
+  doAssert event.retry.isNone == true
+  doAssert event.data == ""
+
+block:
+  # Simple data event
+  let event = SSERawEvent(data: "data: Hello")
+  doAssert formatSSEEvent(event) == "data: Hello\n\n"
+
+block:
+  # Event with type
+  let event = SSERawEvent(event: some("message"), data: "data: Hi")
+  doAssert formatSSEEvent(event) == "event: message\ndata: Hi\n\n"
+
+block:
+  # Event with id
+  let event = SSERawEvent(id: some("123"), data: "data: Test")
+  doAssert formatSSEEvent(event) == "id: 123\ndata: Test\n\n"
+
+block:
+  # Event with retry
+  let event = SSERawEvent(retry: some(5000), data: "data: Test")
+  doAssert formatSSEEvent(event) == "retry: 5000\ndata: Test\n\n"
+
+block:
+  # Multiline data
+  let event = SSERawEvent(data: "data: Line 1\ndata: Line 2")
+  doAssert formatSSEEvent(event) == "data: Line 1\ndata: Line 2\n\n"
+
+block:
+  # Multiline data with trailing newline
+  let event = SSERawEvent(data: "data: Line 1\ndata: Line 2\n")
+  doAssert formatSSEEvent(event) == "data: Line 1\ndata: Line 2\n\n"
+
+block:
+  # All fields present
+  let event = SSERawEvent(
+    event: some("update"),
+    data: "data: test",
+    id: some("123"),
+    retry: some(5000)
+  )
+  let expected = "event: update\nid: 123\nretry: 5000\ndata: test\n\n"
+  doAssert formatSSEEvent(event) == expected
+
+block:
+  # Empty data
+  let event = SSEEvent(data: "")
+  doAssert formatSSEEvent(event) == "\n"
+
+
+block:
+  # SSEConnection fields exist
+  # This just verifies the type compiles correctly
+  discard SSEConnection(
+    server: nil,
+    clientSocket: 0.SocketHandle,
+    clientId: 0,
+    active: false
+  )


### PR DESCRIPTION
- Implementation canonical with the rest of mummy (unlike mummyx)
- User-facing syntax inspired by mummyx
- New examples
- New test

## Stress-Testing

- Default mm:ORC
- Ran hundreds of thousands of streaming queries with opening and closing connections with the incredible speed of mummy
- RSS memory stabilized in an expected range (no leaks)

## Potential Opinion Points

- `SSEEvent` and `SSERawEvent` now implemented on this PR. ~We could have 2 different Objects: `SSEEvent` and `SSEEventRaw` so folks who want an automatic 'data :' prefix can have it, and those who don't can have theirs.~
- `SSEEvent` prefixes event stream chunks with `'data: '` as normal
- `SSERawEvent` does not - useful for NDJSON format and others.