### PR TITLE
Multi address binding

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,5 +24,6 @@ jobs:
     - run: nim c --mm:atomicArc -r -d:useMalloc tests/test_http.nim
       if: ${{ matrix.atomic_arc }}
     - run: nim c -r -d:useMalloc tests/test_http2.nim
+    - run: nim c -r -d:useMalloc tests/test_multi_bind.nim
     - run: nim c -r -d:useMalloc tests/test_websockets.nim
     - run: nim c -r -d:useMalloc -d:mummyNoWorkers tests/fuzz_recv.nim

--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,20 @@
-# ignore files with no extention:
 *
 !*/
 !*.*
-
-# normal ignores:
+nim.cfg
+/vendor
 *.exe
-nimcache
 *.pdb
 *.ilk
-.*
 *.out
 *.sqlite3
+*.out
+/nimcache
+.tool-versions
+*.dSYM/
+nimble.develop
+nimble.paths
+.nimcache
+/deps/
+.nimcache
+nimbledeps

--- a/README.md
+++ b/README.md
@@ -96,6 +96,13 @@ server.serve(Port(8080))
 
 `nim c --threads:on --mm:orc -r examples/basic_router.nim`
 
+To listen on multiple IPv4 and IPv6 addresses using the same port, pass an
+array of addresses to `serve`:
+
+```nim
+server.serve(Port(8080), ["0.0.0.0", "::"])
+```
+
 ## Example WebSocket server
 
 ```nim

--- a/README.md
+++ b/README.md
@@ -96,11 +96,15 @@ server.serve(Port(8080))
 
 `nim c --threads:on --mm:orc -r examples/basic_router.nim`
 
-To listen on multiple IPv4 and IPv6 addresses using the same port, pass an
-array of addresses to `serve`:
+To listen on multiple IPv4 or IPv6 addresses, pass an array of
+`(address, port)` tuples:
 
 ```nim
-server.serve(Port(8080), ["0.0.0.0", "::"])
+server.serve([
+  ("0.0.0.0", Port(8080)),
+  ("::", Port(8080)),
+  ("127.0.0.1", Port(9090))
+])
 ```
 
 ## Example WebSocket server

--- a/src/mummy.nim
+++ b/src/mummy.nim
@@ -1468,21 +1468,19 @@ proc createListeningSocket(
   finally:
     freeAddrInfo(aiList)
 
-proc serveAddresses(
+proc serveBindings(
   server: Server,
-  port: Port,
-  addresses: openArray[string],
+  bindings: openArray[(string, Port)],
   domain: Domain,
   ipv6Only: bool
 ) {.raises: [MummyError].} =
   if server.listeningSockets.len > 0:
     raise newException(MummyError, "Server already has a socket")
+  if bindings.len == 0:
+    raise newException(MummyError, "At least one address and port is required")
 
   try:
-    if addresses.len == 0:
-      raise newException(ValueError, "At least one address is required")
-
-    for address in addresses:
+    for (address, port) in bindings:
       let listeningSocket = createListeningSocket(
         address,
         port,
@@ -1515,19 +1513,17 @@ proc serve*(
   ## caution).
   ## This call does not return unless server.close() is called from another
   ## thread.
-  server.serveAddresses(port, [address], Domain.AF_INET, false)
+  server.serveBindings([(address, port)], Domain.AF_INET, false)
 
 proc serve*(
   server: Server,
-  port: Port,
-  addresses: openArray[string]
+  bindings: openArray[(string, Port)]
 ) {.raises: [MummyError].} =
-  ## The server will serve on every address using the same port. IPv4 and IPv6
-  ## addresses can be used together. Use `["0.0.0.0", "::"]` to listen on all
-  ## IPv4 and IPv6 interfaces (with caution).
+  ## The server will serve on every `(address, port)` binding. IPv4 and IPv6
+  ## addresses and different ports can be used together.
   ## This call does not return unless server.close() is called from another
   ## thread.
-  server.serveAddresses(port, addresses, Domain.AF_UNSPEC, true)
+  server.serveBindings(bindings, Domain.AF_UNSPEC, true)
 
 proc newServer*(
   handler: RequestHandler,

--- a/src/mummy.nim
+++ b/src/mummy.nim
@@ -7,7 +7,7 @@ when not compileOption("threads"):
 
 import mummy/common, mummy/internal, std/atomics, std/base64,
     std/cpuinfo, std/deques, std/hashes, std/nativesockets, std/os,
-    std/parseutils, std/random, std/selectors, std/sets, crunchy,
+    std/monotimes, std/parseutils, std/random, std/selectors, std/sets, crunchy,
     std/tables, std/times, webby/httpheaders, webby/queryparams, webby/urls,
     zippy, std/options
 
@@ -27,7 +27,7 @@ when defined(windows):
   from std/winlean import TCP_NODELAY
   const ipv6OnlyOption = 27 # IPV6_V6ONLY from Winsock2.
 elif defined(posix):
-  from std/posix import IPV6_V6ONLY, TCP_NODELAY
+  from std/posix import ECONNABORTED, IPV6_V6ONLY, TCP_NODELAY
 
 import std/locks
 
@@ -1109,6 +1109,52 @@ proc afterSend(
   if dataEntry.outgoingBuffers.len == 0:
     server.selector.updateHandle2(clientSocket, {Read})
 
+proc acceptClient(
+  listeningSocket: SocketHandle
+): (SocketHandle, string) {.raises: [OSError].} =
+  var
+    peerAddress: Sockaddr_storage
+    peerAddressLen = sizeof(peerAddress).SockLen
+
+  let clientSocket =
+    when defined(linux) and not defined(nimdoc):
+      accept4(
+        listeningSocket,
+        cast[ptr SockAddr](addr peerAddress),
+        addr peerAddressLen,
+        SOCK_CLOEXEC or SOCK_NONBLOCK
+      )
+    else:
+      nativesockets.accept(
+        listeningSocket,
+        cast[ptr SockAddr](addr peerAddress),
+        addr peerAddressLen
+      )
+
+  if clientSocket == osInvalidSocket:
+    return (clientSocket, "")
+
+  when not defined(linux):
+    when declared(setInheritable):
+      if not clientSocket.setInheritable(false):
+        let error = osLastError()
+        clientSocket.close()
+        raiseOSError(error)
+
+  let remoteAddress =
+    try:
+      getAddrString(cast[ptr SockAddr](addr peerAddress))
+    except Exception:
+      ""
+
+  (clientSocket, remoteAddress)
+
+proc isTransientAcceptError(error: OSErrorCode): bool =
+  when defined(windows):
+    error.int32 in [WSAEWOULDBLOCK, WSAECONNRESET, WSAECONNABORTED]
+  else:
+    error.int32 in [EAGAIN, EWOULDBLOCK, EINTR, ECONNABORTED]
+
 proc destroy(server: Server, joinThreads: bool) {.raises: [].} =
   withLock server.taskQueueLock:
     server.destroyCalled = true
@@ -1278,44 +1324,27 @@ proc loopForever(server: Server) {.raises: [OSError, IOSelectorsException].} =
         if Read in readyKey.events:
           let listeningSocket = readyKey.fd.SocketHandle
           let (clientSocket, remoteAddress) =
-            when defined(linux) and not defined(nimdoc):
-              var
-                sockAddr: SockAddr
-                addrLen = sizeof(sockAddr).SockLen
-              let
-                socket =
-                  accept4(
-                    listeningSocket,
-                    sockAddr.addr,
-                    addrLen.addr,
-                    SOCK_CLOEXEC or SOCK_NONBLOCK
-                  )
-                sockAddrStr =
-                  try:
-                    getAddrString(sockAddr.addr)
-                  except Exception as e:
-                    ""
-              (socket, sockAddrStr)
-            else:
-              listeningSocket.accept()
+            acceptClient(listeningSocket)
 
           if clientSocket == osInvalidSocket:
-            continue
+            let error = osLastError()
+            if not isTransientAcceptError(error):
+              raiseOSError(error)
+          else:
+            when not defined(linux):
+              # Not needed on linux where we use SOCK_NONBLOCK.
+              clientSocket.setBlocking(false)
 
-          when not defined(linux):
-            # Not needed on linux where we can use SOCK_NONBLOCK
-            clientSocket.setBlocking(false)
+            if server.tcpNoDelay:
+              server.setNoDelay(clientSocket)
 
-          if server.tcpNoDelay:
-            server.setNoDelay(clientSocket)
+            server.clientSockets.incl(clientSocket)
 
-          server.clientSockets.incl(clientSocket)
-
-          let dataEntry = DataEntry(kind: ClientSocketEntry)
-          dataEntry.clientId = server.rand.next()
-          dataEntry.remoteAddress = remoteAddress
-          dataEntry.recvBuf.setLen(initialRecvBufLen)
-          server.selector.registerHandle2(clientSocket, {Read}, dataEntry)
+            let dataEntry = DataEntry(kind: ClientSocketEntry)
+            dataEntry.clientId = server.rand.next()
+            dataEntry.remoteAddress = remoteAddress
+            dataEntry.recvBuf.setLen(initialRecvBufLen)
+            server.selector.registerHandle2(clientSocket, {Read}, dataEntry)
       elif readyDataEntry.kind == ClientSocketEntry:
         if Error in readyKey.events:
           needClosing.incl(readyKey.fd.SocketHandle)
@@ -1605,13 +1634,11 @@ proc waitUntilReady*(server: Server, timeout: float = 10) =
   ## This is useful when writing tests, where you need to know
   ## the server is ready before you begin sending requests.
   ## If the server is already ready this returns immediately.
-  let start = cpuTime()
+  let start = getMonoTime()
   while true:
     if server.serving.load(moRelaxed):
       return
-    let
-      now = cpuTime()
-      delta = now - start
-    if delta > timeout:
+    let elapsed = getMonoTime() - start
+    if elapsed.inMilliseconds.float > timeout * 1000:
       raise newException(MummyError, "Timeout while waiting for server")
     sleep(100)

--- a/src/mummy.nim
+++ b/src/mummy.nim
@@ -25,8 +25,9 @@ when defined(linux):
 
 when defined(windows):
   from std/winlean import TCP_NODELAY
+  const ipv6OnlyOption = 27 # IPV6_V6ONLY from Winsock2.
 elif defined(posix):
-  from std/posix import TCP_NODELAY
+  from std/posix import IPV6_V6ONLY, TCP_NODELAY
 
 import std/locks
 
@@ -93,7 +94,7 @@ type
     workerThreads: seq[Thread[Server]]
     serving: Atomic[bool]
     destroyCalled: bool
-    socket: SocketHandle
+    listeningSockets: seq[SocketHandle]
     selector: Selector[DataEntry]
     responseQueued, sendQueued, shutdown: SelectEvent
     clientSockets: HashSet[SocketHandle]
@@ -1116,8 +1117,8 @@ proc destroy(server: Server, joinThreads: bool) {.raises: [].} =
       server.selector.close()
     except Exception as e:
       discard # Ignore
-  if server.socket.int != 0:
-    server.socket.close()
+  for listeningSocket in server.listeningSockets:
+    listeningSocket.close()
   for clientSocket in server.clientSockets:
     clientSocket.close()
   broadcast(server.taskQueueCond)
@@ -1271,9 +1272,11 @@ proc loopForever(server: Server) {.raises: [OSError, IOSelectorsException].} =
 
       # echo "Socket ready: ", readyKey.fd, " ", readyKey.events
 
-      if readyKey.fd == server.socket.int:
+      let readyDataEntry = server.selector.getData(readyKey.fd)
+      if readyDataEntry.kind == ServerSocketEntry:
         # We should have a new client socket to accept
         if Read in readyKey.events:
+          let listeningSocket = readyKey.fd.SocketHandle
           let (clientSocket, remoteAddress) =
             when defined(linux) and not defined(nimdoc):
               var
@@ -1282,7 +1285,7 @@ proc loopForever(server: Server) {.raises: [OSError, IOSelectorsException].} =
               let
                 socket =
                   accept4(
-                    server.socket,
+                    listeningSocket,
                     sockAddr.addr,
                     addrLen.addr,
                     SOCK_CLOEXEC or SOCK_NONBLOCK
@@ -1294,7 +1297,7 @@ proc loopForever(server: Server) {.raises: [OSError, IOSelectorsException].} =
                     ""
               (socket, sockAddrStr)
             else:
-              server.socket.accept()
+              listeningSocket.accept()
 
           if clientSocket == osInvalidSocket:
             continue
@@ -1313,12 +1316,12 @@ proc loopForever(server: Server) {.raises: [OSError, IOSelectorsException].} =
           dataEntry.remoteAddress = remoteAddress
           dataEntry.recvBuf.setLen(initialRecvBufLen)
           server.selector.registerHandle2(clientSocket, {Read}, dataEntry)
-      else: # Client socket
+      elif readyDataEntry.kind == ClientSocketEntry:
         if Error in readyKey.events:
           needClosing.incl(readyKey.fd.SocketHandle)
           continue
 
-        let dataEntry = server.selector.getData(readyKey.fd)
+        let dataEntry = readyDataEntry
 
         if Read in readyKey.events:
           # Expand the buffer if it is full
@@ -1406,56 +1409,89 @@ proc close*(server: Server) {.raises: [], gcsafe.} =
   ## Cleanly stops and deallocates the server.
   ## In-flight request handler calls will be allowed to finish.
   ## No additional handler calls will be dispatched even if they are queued.
-  if server.socket.int != 0:
+  if server.listeningSockets.len > 0:
     server.trigger(server.shutdown)
   else:
     server.destroy(true)
 
-proc serve*(
+proc createListeningSocket(
+  address: string,
+  port: Port,
+  domain: Domain,
+  ipv6Only: bool
+): SocketHandle =
+  let aiList = getAddrInfo(
+    address,
+    port,
+    domain,
+    SockType.SOCK_STREAM,
+    Protocol.IPPROTO_TCP,
+  )
+  try:
+    var
+      ai = aiList
+      lastError = default(OSErrorCode)
+    while ai != nil:
+      let listeningSocket = createNativeSocket(
+        ai.ai_family,
+        ai.ai_socktype,
+        ai.ai_protocol,
+        false
+      )
+      if listeningSocket == osInvalidSocket:
+        raiseOSError(osLastError())
+
+      try:
+        listeningSocket.setBlocking(false)
+        listeningSocket.setSockOptInt(SOL_SOCKET, SO_REUSEADDR, 1)
+        if ipv6Only and ai.ai_family == nativesockets.toInt(Domain.AF_INET6):
+          listeningSocket.setSockOptInt(
+            nativesockets.toInt(Protocol.IPPROTO_IPV6).int,
+            when defined(windows): ipv6OnlyOption else: IPV6_V6ONLY.int,
+            1
+          )
+
+        if bindAddr(listeningSocket, ai.ai_addr, ai.ai_addrlen.SockLen) < 0:
+          raiseOSError(osLastError())
+        if nativesockets.listen(listeningSocket, listenBacklogLen) < 0:
+          raiseOSError(osLastError())
+        return listeningSocket
+      except OSError as e:
+        lastError = e.errorCode.OSErrorCode
+        listeningSocket.close()
+
+      ai = ai.ai_next
+
+    if lastError != default(OSErrorCode):
+      raiseOSError(lastError)
+    raise newException(IOError, "Could not resolve address: " & address)
+  finally:
+    freeAddrInfo(aiList)
+
+proc serveAddresses(
   server: Server,
   port: Port,
-  address = "localhost"
+  addresses: openArray[string],
+  domain: Domain,
+  ipv6Only: bool
 ) {.raises: [MummyError].} =
-  ## The server will serve on the address and port. The default address is
-  ## localhost. Use "0.0.0.0" to make the server externally accessible (with
-  ## caution).
-  ## This call does not return unless server.close() is called from another
-  ## thread.
-
-  if server.socket.int != 0:
+  if server.listeningSockets.len > 0:
     raise newException(MummyError, "Server already has a socket")
 
   try:
-    server.socket = createNativeSocket(
-      Domain.AF_INET,
-      SockType.SOCK_STREAM,
-      Protocol.IPPROTO_TCP,
-      false
-    )
-    if server.socket == osInvalidSocket:
-      raiseOSError(osLastError())
+    if addresses.len == 0:
+      raise newException(ValueError, "At least one address is required")
 
-    server.socket.setBlocking(false)
-    server.socket.setSockOptInt(SOL_SOCKET, SO_REUSEADDR, 1)
-
-    let ai = getAddrInfo(
-      address,
-      port,
-      Domain.AF_INET,
-      SockType.SOCK_STREAM,
-      Protocol.IPPROTO_TCP,
-    )
-    try:
-      if bindAddr(server.socket, ai.ai_addr, ai.ai_addrlen.SockLen) < 0:
-        raiseOSError(osLastError())
-    finally:
-      freeAddrInfo(ai)
-
-    if nativesockets.listen(server.socket, listenBacklogLen) < 0:
-      raiseOSError(osLastError())
-
-    let dataEntry = DataEntry(kind: ServerSocketEntry)
-    server.selector.registerHandle2(server.socket, {Read}, dataEntry)
+    for address in addresses:
+      let listeningSocket = createListeningSocket(
+        address,
+        port,
+        domain,
+        ipv6Only
+      )
+      server.listeningSockets.add(listeningSocket)
+      let dataEntry = DataEntry(kind: ServerSocketEntry)
+      server.selector.registerHandle2(listeningSocket, {Read}, dataEntry)
   except Exception as e:
     server.destroy(true)
     raise currentExceptionAsMummyError()
@@ -1468,6 +1504,30 @@ proc serve*(
     server.log(ErrorLevel, e.msg & "\n" & e.getStackTrace())
     server.destroy(false)
     raise currentExceptionAsMummyError()
+
+proc serve*(
+  server: Server,
+  port: Port,
+  address = "localhost"
+) {.raises: [MummyError].} =
+  ## The server will serve on the address and port. The default address is
+  ## localhost. Use "0.0.0.0" to make the server externally accessible (with
+  ## caution).
+  ## This call does not return unless server.close() is called from another
+  ## thread.
+  server.serveAddresses(port, [address], Domain.AF_INET, false)
+
+proc serve*(
+  server: Server,
+  port: Port,
+  addresses: openArray[string]
+) {.raises: [MummyError].} =
+  ## The server will serve on every address using the same port. IPv4 and IPv6
+  ## addresses can be used together. Use `["0.0.0.0", "::"]` to listen on all
+  ## IPv4 and IPv6 interfaces (with caution).
+  ## This call does not return unless server.close() is called from another
+  ## thread.
+  server.serveAddresses(port, addresses, Domain.AF_UNSPEC, true)
 
 proc newServer*(
   handler: RequestHandler,

--- a/tests/test_multi_bind.nim
+++ b/tests/test_multi_bind.nim
@@ -1,11 +1,19 @@
 import mummy, std/[assertions, nativesockets, os, strutils]
 
-const testPort = Port(18081)
+const
+  testPort = Port(18081)
+  otherPort = Port(18082)
 
 proc handler(request: Request) =
   request.respond(200, body = "Hello from Mummy!")
 
-proc fetch(address: string, domain: Domain): string =
+block emptyBindings:
+  let emptyServer = newServer(handler)
+  doAssertRaises MummyError:
+    emptyServer.serve([])
+  emptyServer.close()
+
+proc fetch(address: string, port: Port, domain: Domain): string =
   let socket = createNativeSocket(
     domain,
     SockType.SOCK_STREAM,
@@ -18,7 +26,7 @@ proc fetch(address: string, domain: Domain): string =
   try:
     let ai = getAddrInfo(
       address,
-      testPort,
+      port,
       domain,
       SockType.SOCK_STREAM,
       Protocol.IPPROTO_TCP,
@@ -50,14 +58,21 @@ var requesterThread: Thread[void]
 proc requesterProc() =
   server.waitUntilReady()
   try:
-    let ipv4Response = fetch("127.0.0.1", Domain.AF_INET)
+    let ipv4Response = fetch("127.0.0.1", testPort, Domain.AF_INET)
     doAssert ipv4Response.endsWith("Hello from Mummy!")
 
-    let ipv6Response = fetch("::1", Domain.AF_INET6)
+    let ipv6Response = fetch("::1", testPort, Domain.AF_INET6)
     doAssert ipv6Response.endsWith("Hello from Mummy!")
+
+    let otherPortResponse = fetch("127.0.0.1", otherPort, Domain.AF_INET)
+    doAssert otherPortResponse.endsWith("Hello from Mummy!")
   finally:
     server.close()
 
 createThread(requesterThread, requesterProc)
 
-server.serve(testPort, ["0.0.0.0", "::"])
+server.serve([
+  ("0.0.0.0", testPort),
+  ("::", testPort),
+  ("127.0.0.1", otherPort)
+])

--- a/tests/test_multi_bind.nim
+++ b/tests/test_multi_bind.nim
@@ -1,8 +1,9 @@
-import mummy, std/[assertions, nativesockets, os, strutils]
+import mummy, std/[assertions, net, strutils]
 
 const
   testPort = Port(18081)
   otherPort = Port(18082)
+  requestTimeout = 5_000
 
 proc handler(request: Request) =
   request.respond(200, body = "Hello from Mummy!")
@@ -11,44 +12,29 @@ block emptyBindings:
   let emptyServer = newServer(handler)
   doAssertRaises MummyError:
     emptyServer.serve([])
+  doAssertRaises MummyError:
+    emptyServer.waitUntilReady(0.1)
   emptyServer.close()
 
 proc fetch(address: string, port: Port, domain: Domain): string =
-  let socket = createNativeSocket(
+  let socket = newSocket(
     domain,
     SockType.SOCK_STREAM,
     Protocol.IPPROTO_TCP,
-    false
+    buffered = false
   )
-  if socket == osInvalidSocket:
-    raiseOSError(osLastError())
 
   try:
-    let ai = getAddrInfo(
-      address,
-      port,
-      domain,
-      SockType.SOCK_STREAM,
-      Protocol.IPPROTO_TCP,
-    )
-    try:
-      if socket.connect(ai.ai_addr, ai.ai_addrlen.SockLen) < 0:
-        raiseOSError(osLastError())
-    finally:
-      freeAddrInfo(ai)
+    socket.connect(address, port, timeout = requestTimeout)
 
     let request = "GET / HTTP/1.0\r\nHost: localhost\r\n\r\n"
-    if socket.send(request.cstring, request.len.cint, 0) < 0:
-      raiseOSError(osLastError())
+    socket.send(request)
 
-    var buffer = newString(4096)
     while true:
-      let bytesReceived = socket.recv(buffer[0].addr, buffer.len.cint, 0)
-      if bytesReceived < 0:
-        raiseOSError(osLastError())
-      if bytesReceived == 0:
+      let chunk = socket.recv(4096, timeout = requestTimeout)
+      if chunk.len == 0:
         break
-      result.add(buffer[0 ..< bytesReceived])
+      result.add(chunk)
   finally:
     socket.close()
 

--- a/tests/test_multi_bind.nim
+++ b/tests/test_multi_bind.nim
@@ -1,0 +1,63 @@
+import mummy, std/[assertions, nativesockets, os, strutils]
+
+const testPort = Port(18081)
+
+proc handler(request: Request) =
+  request.respond(200, body = "Hello from Mummy!")
+
+proc fetch(address: string, domain: Domain): string =
+  let socket = createNativeSocket(
+    domain,
+    SockType.SOCK_STREAM,
+    Protocol.IPPROTO_TCP,
+    false
+  )
+  if socket == osInvalidSocket:
+    raiseOSError(osLastError())
+
+  try:
+    let ai = getAddrInfo(
+      address,
+      testPort,
+      domain,
+      SockType.SOCK_STREAM,
+      Protocol.IPPROTO_TCP,
+    )
+    try:
+      if socket.connect(ai.ai_addr, ai.ai_addrlen.SockLen) < 0:
+        raiseOSError(osLastError())
+    finally:
+      freeAddrInfo(ai)
+
+    let request = "GET / HTTP/1.0\r\nHost: localhost\r\n\r\n"
+    if socket.send(request.cstring, request.len.cint, 0) < 0:
+      raiseOSError(osLastError())
+
+    var buffer = newString(4096)
+    while true:
+      let bytesReceived = socket.recv(buffer[0].addr, buffer.len.cint, 0)
+      if bytesReceived < 0:
+        raiseOSError(osLastError())
+      if bytesReceived == 0:
+        break
+      result.add(buffer[0 ..< bytesReceived])
+  finally:
+    socket.close()
+
+let server = newServer(handler)
+var requesterThread: Thread[void]
+
+proc requesterProc() =
+  server.waitUntilReady()
+  try:
+    let ipv4Response = fetch("127.0.0.1", Domain.AF_INET)
+    doAssert ipv4Response.endsWith("Hello from Mummy!")
+
+    let ipv6Response = fetch("::1", Domain.AF_INET6)
+    doAssert ipv6Response.endsWith("Hello from Mummy!")
+  finally:
+    server.close()
+
+createThread(requesterThread, requesterProc)
+
+server.serve(testPort, ["0.0.0.0", "::"])


### PR DESCRIPTION
This is a variant to https://github.com/guzba/mummy/pull/145 which goes for supporting multiple listening sockets. It adds a new `server` that takes an `openArray[(string, Port)]`. It also uses AF_UNSPEC so mixed IPv4/IPv6 works too.

Long term this might a nicer API as it also allows binding multiple IP and/or ports. This can be helpful in some situations where you might want to bind different ports/ip's.

Though for "multi-tenancy" using IP's wouldn't be feasible without a way for request handlers to get bound port the request came from. Still that should be easy.